### PR TITLE
Update agent-team roster with 10 new focused agents

### DIFF
--- a/config/claude/skills/agent-team/references/agent-roster.md
+++ b/config/claude/skills/agent-team/references/agent-roster.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Roster
-description: Built-in agent definitions and discovery procedure for agent teams
+description: Agent definitions and discovery procedure for agent teams
 tags: [agents, roster, discovery]
 ---
 
@@ -12,28 +12,38 @@ Before selecting agents, discover what's available:
 
 1. Check `~/.claude/agents/*.md` (global) and `.claude/agents/*.md` (project-local)
 2. Read each agent's frontmatter to understand capabilities
-3. Custom agents that overlap with built-in ones take precedence (tailored to user's workflow)
-4. Present both custom and built-in agents when recommending teams
+3. Custom agents that overlap with built-in ones take precedence
+4. Present discovered agents when recommending teams
 
-## General-Purpose Agents
+## Tier 1 — Core (use on most teams)
 
-| Agent | Lens | Memory | Best For |
-|-------|------|--------|----------|
-| **tech-lead** | Senior leadership, architecture decisions | none | Code reviews, architectural guidance, technical strategy |
-| **implementation-investigator** | Reverse-engineering codebases | none | Understanding how things work, tracing code paths |
-| **refactoring-strategist** | Code quality, design patterns | none | Identifying tech debt, planning refactors |
-| **security-auditor** | Threat modeling, vulnerabilities | user | Security reviews, dependency audits, threat modeling |
-| **test-strategist** | Test architecture, TDD, coverage | user | Test design, coverage gaps, flaky test diagnosis |
-| **performance-analyst** | Complexity, profiling, optimization | user | Bottleneck analysis, caching strategy, query optimization |
-| **api-designer** | Interface ergonomics, consumer UX | none | API design, CLI design, library interface review |
-| **domain-modeler** | DDD, schemas, state machines | project | Data modeling, bounded contexts, state management |
-| **reliability-engineer** | Failure modes, observability | user | Error handling, resilience patterns, monitoring design |
-| **devils-advocate** | Assumption challenging, simplicity | none | Preventing groupthink, simplicity advocacy, stress-testing proposals |
+| Agent | Lens | Model | Best For |
+|-------|------|-------|----------|
+| **devils-advocate** | Challenges assumptions, argues for doing less | opus | Architectural decisions, RFCs, any "obvious" solution |
+| **simplifier** | Rejects complexity, argues for deletion | sonnet | PR reviews, refactoring proposals, over-engineered code |
+| **error-path-reviewer** | Focuses on what happens when things go wrong | sonnet | I/O, networking, parsing, anything that can fail |
+| **contract-reviewer** | Guards backward compatibility and interface stability | sonnet | API changes, schema migrations, RPC modifications |
 
-## Domain-Specific Agents
+## Tier 2 — Common Tasks
 
-| Agent | Lens | Best For |
-|-------|------|----------|
-| **kubernetes-architect** | K8s infrastructure | Cluster design, networking, storage, security |
-| **skaffold-deployment-expert** | K8s dev workflows | Skaffold config, local dev, CI/CD with Skaffold |
-| **fedora-sysadmin** | Fedora Linux administration | DNF, SELinux, systemd, system troubleshooting |
+| Agent | Lens | Model | Best For |
+|-------|------|-------|----------|
+| **test-strategist** | Right tests at right layer, rejects mocking theater | sonnet | Test strategy, reviewing test code, coverage debates |
+| **data-model-analyst** | Schema integrity, migration safety, query correctness | sonnet | Table changes, migrations, query logic review |
+| **dependency-skeptic** | Questions every new dependency | sonnet | Library additions, dependency updates, Cargo.toml/package.json changes |
+| **concurrency-reviewer** | Finds races, deadlocks, cancellation bugs | opus | Async code, threads, channels, locks, shared state |
+| **deploy-safety-reviewer** | Evaluates rollout risk and rollback safety | sonnet | Pre-deploy review, K8s manifests, migration ordering |
+| **observability-advisor** | Argues for instrumentation and debuggability | sonnet | New services, error paths, performance-sensitive code |
+
+## Key Tension Pairs
+
+| Pair | What They Debate |
+|------|-----------------|
+| devils-advocate vs everyone | "Do we even need this?" |
+| simplifier vs error-path-reviewer | "Keep it simple" vs "Handle this failure" |
+| simplifier vs observability-advisor | "That's noise" vs "You'll need this at 3 AM" |
+| contract-reviewer vs simplifier | "You'll break consumers" vs "Just change it" |
+| dependency-skeptic vs anyone adding a library | "Write it yourself" vs "Don't reinvent the wheel" |
+| test-strategist vs data-model-analyst | "Test the behavior" vs "Test the constraints" |
+| concurrency-reviewer vs simplifier | "This needs synchronization" vs "Remove the concurrency" |
+| deploy-safety-reviewer vs devils-advocate | "Here's how to ship it safely" vs "Don't ship it at all" |

--- a/config/claude/skills/agent-team/references/composition.md
+++ b/config/claude/skills/agent-team/references/composition.md
@@ -1,6 +1,6 @@
 ---
 title: Smart Composition
-description: Algorithm for composing agent teams from task descriptions, including tension pairs
+description: Algorithm for composing agent teams from task descriptions
 tags: [composition, algorithm, tension, team-sizing]
 ---
 
@@ -12,24 +12,27 @@ When the user describes a task without specifying agents, use this process to re
 
 | Signal in Request | Task Type | Likely Agents |
 |-------------------|-----------|---------------|
-| "review", "check", "audit" | Review | security-auditor, performance-analyst, test-strategist |
-| "design", "plan", "architect" | Design | api-designer, domain-modeler, devils-advocate |
-| "build", "implement", "create" | Development | api-designer, domain-modeler, test-strategist |
-| "debug", "fix", "investigate" | Investigation | implementation-investigator, reliability-engineer, devils-advocate |
-| "refactor", "clean up", "improve" | Refactoring | refactoring-strategist, test-strategist, performance-analyst |
-| "harden", "production-ready" | Hardening | security-auditor, reliability-engineer, performance-analyst |
-| "migrate", "upgrade" | Migration | tech-lead, reliability-engineer, devils-advocate |
+| "review", "check", "audit" | Review | error-path-reviewer, contract-reviewer, simplifier |
+| "design", "plan", "architect" | Design | contract-reviewer, devils-advocate, simplifier |
+| "build", "implement", "create" | Development | contract-reviewer, test-strategist, error-path-reviewer |
+| "debug", "fix", "investigate" | Investigation | error-path-reviewer, concurrency-reviewer, devils-advocate |
+| "refactor", "clean up", "improve" | Refactoring | simplifier, test-strategist, contract-reviewer |
+| "harden", "production-ready" | Hardening | error-path-reviewer, deploy-safety-reviewer, observability-advisor |
+| "migrate", "upgrade" | Migration | contract-reviewer, deploy-safety-reviewer, devils-advocate |
+| "add dependency", "new library" | Dependency | dependency-skeptic, simplifier, contract-reviewer |
+| "deploy", "ship", "release" | Deployment | deploy-safety-reviewer, observability-advisor, error-path-reviewer |
 
 ## 2. Add Required Perspectives
 
 Based on the task, consider adding:
-- Touches **security boundaries**? → security-auditor
-- Involves **data modeling**? → domain-modeler
-- Needs **API/interface design**? → api-designer
-- **Performance critical**? → performance-analyst
-- Needs **test coverage**? → test-strategist
+- Touches **error handling or I/O**? → error-path-reviewer
+- Changes **public interfaces**? → contract-reviewer
+- Involves **database schemas**? → data-model-analyst
+- Adds **new dependencies**? → dependency-skeptic
+- Has **concurrent/async code**? → concurrency-reviewer
 - **Major decision**? → devils-advocate
-- Involves **failure handling**? → reliability-engineer
+- Going to **production**? → deploy-safety-reviewer + observability-advisor
+- Feels **over-engineered**? → simplifier
 
 ## 3. Select Productive Tension Pairs
 
@@ -37,12 +40,12 @@ Agents whose lenses naturally conflict create better outcomes through debate:
 
 | Tension Pair | What They Debate |
 |-------------|-----------------|
-| security-auditor vs performance-analyst | "Is the security measure too expensive?" |
-| api-designer vs domain-modeler | "Clean for consumers?" vs "Correct for the domain?" |
-| reliability-engineer vs performance-analyst | "Add resilience overhead" vs "Reduce latency" |
+| simplifier vs error-path-reviewer | "Keep it simple" vs "Handle this failure mode" |
+| simplifier vs observability-advisor | "That's noise, delete it" vs "You'll need this at 3 AM" |
+| contract-reviewer vs simplifier | "You'll break consumers" vs "Just change the API" |
+| dependency-skeptic vs anyone adding a lib | "Write it yourself" vs "Don't reinvent the wheel" |
 | devils-advocate vs everyone | "Do we even need this?" |
-| test-strategist vs performance-analyst | "More test coverage" vs "Faster test suite" |
-| tech-lead vs devils-advocate | "Best practice says..." vs "In our context..." |
+| concurrency-reviewer vs simplifier | "Add synchronization" vs "Remove the shared state" |
 
 ## 4. Right-Size the Team
 

--- a/config/claude/skills/agent-team/references/recipes.md
+++ b/config/claude/skills/agent-team/references/recipes.md
@@ -6,41 +6,40 @@ tags: [recipes, compositions, examples]
 
 # Proven Team Compositions
 
-## Design Review (3 agents)
+## Code Review (3 agents)
 
-**When**: Evaluating a new feature design, API shape, or architecture proposal.
+**When**: Reviewing a PR, evaluating code quality, or auditing a module.
 
 ```
-Create an agent team for a design review:
-- api-designer: evaluate the interface from the consumer's perspective
-- domain-modeler: evaluate whether the data model is correct
-- devils-advocate: challenge assumptions and argue for simpler alternatives
-Have them review [DESCRIBE WHAT] and debate their findings.
+Create a team to review [CODE/PR]:
+- error-path-reviewer: find failure modes and unhandled errors
+- simplifier: identify unnecessary complexity
+- contract-reviewer: check for breaking changes
+Synthesize findings into a single review.
 ```
 
 ## Hardening (3 agents)
 
-**When**: Preparing a service for production, auditing existing systems.
+**When**: Preparing a service for production.
 
 ```
-Create an agent team to harden [SERVICE/MODULE]:
-- security-auditor: find vulnerabilities and attack vectors
-- reliability-engineer: identify failure modes and missing resilience
-- performance-analyst: find bottlenecks and scaling issues
-Have each reviewer work independently, then synthesize findings.
+Create a team to harden [SERVICE]:
+- error-path-reviewer: find failure modes and missing resilience
+- deploy-safety-reviewer: evaluate rollout safety and rollback plans
+- observability-advisor: find observability gaps
+Each reviewer works independently, then synthesize findings.
 ```
 
-## Full Architecture Review (4 agents)
+## Design Review (3 agents)
 
-**When**: Major architectural decisions, system design reviews.
+**When**: Evaluating a new feature design or architecture proposal.
 
 ```
-Create an agent team to review [ARCHITECTURE/DESIGN]:
-- tech-lead: evaluate overall approach and team impact
-- security-auditor: assess security implications
-- performance-analyst: analyze scaling and efficiency
-- devils-advocate: challenge necessity and complexity
-Require plan approval before any changes.
+Create a team to review [DESIGN]:
+- contract-reviewer: evaluate interface stability and compatibility
+- simplifier: challenge unnecessary complexity
+- devils-advocate: question whether we need this at all
+Have them debate and converge on a recommendation.
 ```
 
 ## Feature Development (3 agents)
@@ -48,72 +47,64 @@ Require plan approval before any changes.
 **When**: Building a new feature with clear scope.
 
 ```
-Create an agent team to implement [FEATURE]:
-- api-designer: design the interface and contracts
-- domain-modeler: design the data model and state management
-- test-strategist: write tests in parallel based on the design
-Have the api-designer and domain-modeler coordinate on the contract,
-then the test-strategist writes tests against it.
+Create a team to review the plan for [FEATURE]:
+- contract-reviewer: evaluate the interface design
+- test-strategist: plan the testing approach
+- error-path-reviewer: identify failure modes to handle
 ```
 
-## Pre-Production Audit (4 agents)
+## Pre-Deploy Audit (3 agents)
 
-**When**: Final quality check before shipping.
+**When**: Final check before shipping to production.
 
 ```
-Create an agent team to audit [SERVICE] before production:
-- security-auditor: security vulnerabilities and dependency risks
-- reliability-engineer: error handling and observability gaps
-- test-strategist: test coverage and verification completeness
-- performance-analyst: performance bottlenecks and scaling limits
-Each reviewer should produce a findings report with severity ratings.
+Create a team to audit [SERVICE] before deploy:
+- deploy-safety-reviewer: rollout risk and rollback plan
+- observability-advisor: monitoring and alerting gaps
+- error-path-reviewer: unhandled failure modes
+Each produces a go/no-go recommendation.
 ```
 
 ## Investigation (3 agents)
 
-**When**: Understanding an unfamiliar codebase or debugging complex issues.
+**When**: Debugging complex issues or understanding unfamiliar code.
 
 ```
-Create an agent team to investigate [TOPIC/BUG]:
-- implementation-investigator: trace code paths and map architecture
+Create a team to investigate [TOPIC/BUG]:
+- error-path-reviewer: trace error paths and failure modes
 - devils-advocate: challenge initial hypotheses
-- reliability-engineer: analyze failure modes and error paths
-Have them share findings and challenge each other's conclusions.
+- concurrency-reviewer: analyze timing-dependent behavior
+Have them share findings and challenge each other.
 ```
 
-## Refactoring (3 agents)
+## Dependency Evaluation (2 agents)
 
-**When**: Planning and executing a significant refactor.
-
-```
-Create an agent team to refactor [MODULE]:
-- refactoring-strategist: identify smells and plan the refactoring
-- test-strategist: ensure test safety net exists before changes
-- performance-analyst: verify no performance regressions
-Require plan approval from the refactoring-strategist before any changes.
-```
-
-## Debugging with Competing Hypotheses (4-5 agents)
-
-**When**: Root cause is unclear, multiple theories exist.
+**When**: Evaluating whether to add a new library or framework.
 
 ```
-Users report [SYMPTOM]. Create an agent team to investigate:
-- Teammate 1: investigate [hypothesis A]
-- Teammate 2: investigate [hypothesis B]
-- Teammate 3: investigate [hypothesis C]
-- devils-advocate: challenge each theory and look for what they're missing
-Have them actively try to disprove each other's theories.
-Update findings only when there's consensus.
+Create a team to evaluate adding [DEPENDENCY]:
+- dependency-skeptic: assess necessity, risk, and alternatives
+- devils-advocate: argue for the simplest path (maybe don't add it)
 ```
 
-## K8s Deployment Review (3 agents)
+## Database Change Review (3 agents)
 
-**When**: Reviewing Kubernetes deployments and infrastructure.
+**When**: Reviewing schema changes, migrations, or query patterns.
 
 ```
-Create an agent team to review [K8S DEPLOYMENT]:
-- kubernetes-architect: evaluate cluster architecture and configs
-- security-auditor: assess RBAC, network policies, secrets management
-- reliability-engineer: evaluate health checks, resource limits, disruption budgets
+Create a team to review [MIGRATION/SCHEMA]:
+- data-model-analyst: schema correctness and migration safety
+- contract-reviewer: backward compatibility with running code
+- deploy-safety-reviewer: rollout ordering and rollback path
+```
+
+## Async/Concurrent Code Review (3 agents)
+
+**When**: Reviewing code with threads, async/await, channels, or shared state.
+
+```
+Create a team to review [ASYNC CODE]:
+- concurrency-reviewer: races, deadlocks, cancellation safety
+- error-path-reviewer: error handling in concurrent context
+- simplifier: can the concurrency be eliminated?
 ```


### PR DESCRIPTION
## Summary

- Replace 13 general-purpose and domain-specific agents with 10 focused review agents organized into Tier 1 (Core) and Tier 2 (Common Tasks)
- Update composition algorithm with new agent names, two new task types (Dependency, Deployment), and revised tension pairs
- Rewrite recipes to use the new agents: add Code Review, Pre-Deploy Audit, Dependency Evaluation, Database Change Review, and Async/Concurrent Code Review; remove K8s Deployment Review, Full Architecture Review, and Debugging with Competing Hypotheses

## Test plan

- [x] Files exist: `ls -la config/claude/skills/agent-team/references/`
- [x] Agent names are consistent across all three files
- [x] Markdown renders correctly (tables, code blocks, frontmatter)